### PR TITLE
cleanup

### DIFF
--- a/src/media_info.rs
+++ b/src/media_info.rs
@@ -1,10 +1,21 @@
 use human_repr::HumanDurationData;
 use std::fmt;
+use human_repr::HumanDuration;
 
 pub struct MediaInfo {
     pub title: String,
     pub artist: String,
     pub position: HumanDurationData,
+}
+
+impl MediaInfo {
+    pub fn empty() -> MediaInfo {
+        MediaInfo {
+            title: "No Music Playing".to_owned(),
+            artist: "".to_owned(),
+            position: 0_i64.human_duration(),
+        }
+    }
 }
 
 impl fmt::Display for MediaInfo {


### PR DESCRIPTION
replace ok-err matches with question marks (bubbles error up to function call)
create MediaInfo::empty() to reduce repetitive empty struct creations
create get_session() function that was used 4 times