### PR TITLE
dont create MediaInfo unless necessary

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,18 @@ enum Commands {
     Position,
 }
 
+pub trait ResultOkOr<T> {
+    fn ok_or(self, or: T) -> T;
+}
+
+impl<T, E> ResultOkOr<T> for Result<T, E> {
+    fn ok_or(self, or: T) -> T {
+        match self {
+            Ok(stuff) => stuff,
+            _ => or,
+        }
+    }
+}
 #[tokio::main]
 async fn main() -> Result<(), ()> {
     let cli = Cli::parse();
@@ -31,25 +43,16 @@ async fn main() -> Result<(), ()> {
     match cli.command {
         Some(case) => match case {
             Commands::Title => {
-                if let Ok(title) = get_title().await {
-                    println!("{}", title)
-                } else {
-                    println!("No Music Playing")
-                }
+                let playing = get_title().await.ok_or("No Song Playing".to_owned());
+                println!("{}", playing)
             }
             Commands::Artist => {
-                if let Ok(artist) = get_artist().await {
-                    println!("{}", artist)
-                } else {
-                    println!("No Artist")
-                }
+                let playing = get_artist().await.ok_or("No Artist".to_owned());
+                println!("{}", playing)
             }
             Commands::Position => {
-                if let Ok(position) = get_position().await {
-                    println!("{}", position)
-                } else {
-                    println!("0ns")
-                }
+                let playing = get_position().await.ok_or(0.human_duration());
+                println!("{}", playing)
             }
         },
         None => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,7 @@ async fn main() -> Result<(), ()> {
                 Ok(song) => song,
                 Err(_) => MediaInfo {
                     title: "No Music Playing".to_owned(),
-                    artist: "".to_owned(),
+                    artist: "No Artist".to_owned(),
                     position: 0_i64.human_duration(),
                 },
             };
@@ -98,8 +98,7 @@ async fn get_position() -> Result<HumanDurationData, windows::core::Error> {
     let current_session = get_session().await?;
     let timeline = current_session.GetTimelineProperties()?;
     let position = timeline.Position()?;
-    let base: i64 = 10;
-    Ok((position.Duration / base.pow(7)).human_duration())
+    Ok((position.Duration / 10_i64.pow(7)).human_duration())
 }
 
 async fn get_title() -> Result<String, windows::core::Error> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,21 +34,21 @@ async fn main() -> Result<(), ()> {
                 if let Ok(title) = get_title().await {
                     println!("{}", title)
                 } else {
-                    println!("{}", 0.human_duration())
+                    println!("No Music Playing")
                 }
             }
             Commands::Artist => {
                 if let Ok(artist) = get_artist().await {
                     println!("{}", artist)
                 } else {
-                    println!("{}", 0.human_duration())
+                    println!("No Artist")
                 }
             }
             Commands::Position => {
                 if let Ok(position) = get_position().await {
                     println!("{}", position)
                 } else {
-                    println!("{}", 0.human_duration())
+                    println!("0ns")
                 }
             }
         },

--- a/src/media_info.rs
+++ b/src/media_info.rs
@@ -1,21 +1,10 @@
-use human_repr::HumanDurationData;
 use std::fmt;
-use human_repr::HumanDuration;
+use human_repr::HumanDurationData;
 
 pub struct MediaInfo {
     pub title: String,
     pub artist: String,
     pub position: HumanDurationData,
-}
-
-impl MediaInfo {
-    pub fn empty() -> MediaInfo {
-        MediaInfo {
-            title: "No Music Playing".to_owned(),
-            artist: "".to_owned(),
-            position: 0_i64.human_duration(),
-        }
-    }
 }
 
 impl fmt::Display for MediaInfo {

--- a/src/media_info.rs
+++ b/src/media_info.rs
@@ -1,5 +1,5 @@
-use std::fmt;
 use human_repr::HumanDurationData;
+use std::fmt;
 
 pub struct MediaInfo {
     pub title: String,


### PR DESCRIPTION
stops the creation of MediaInfo with empty components, when it isn't necessary