### PR TITLE
remove the ok_or, replace with a language feature

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -44,14 +44,13 @@ async fn main() -> Result<(), ()> {
             }
         },
         None => {
-            let playing = match get_media_info().await {
-                Ok(song) => song,
-                Err(_) => MediaInfo {
+            let playing = get_media_info().await.unwrap_or_else(|_|
+                MediaInfo {
                     title: "No Music Playing".to_owned(),
                     artist: "No Artist".to_owned(),
                     position: 0_i64.human_duration(),
-                },
-            };
+                }
+            );
             println!("{}", playing)
         }
     }


### PR DESCRIPTION
replaces `ok_or` implementation with rust's own `unwrap_or_else`
rename `info` variable to `properties` as what the function is called. this also makes it less ambiguous between info (`MediaInfo`) and properties (from winapi)